### PR TITLE
gdal base image was not compatible with other libraries any more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,7 @@
-FROM osgeo/gdal:ubuntu-full-3.6.3
+FROM ghcr.io/osgeo/gdal:ubuntu-full-latest
 MAINTAINER joeakeem "info@singletrail-map.ch"
-
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get clean
-
-RUN apt-get update -y && apt-get install -y software-properties-common
-RUN add-apt-repository ppa:ubuntugis/ppa
-
 RUN apt-get update -y && apt-get install -y \
         postgis \
         make \
@@ -30,7 +25,7 @@ RUN apt-get update -y && apt-get install -y \
         wget \
         python3-gdal \
         gdal-bin \
-		parallel
+        parallel
 
 # build & install tippecanoe
 WORKDIR /tmp
@@ -38,15 +33,11 @@ RUN git clone https://github.com/mapbox/tippecanoe.git
 WORKDIR /tmp/tippecanoe
 RUN make
 RUN make install
-
 # cleanup
 RUN rm -rf /tmp/tippecanoe
-
 # Add the Makefile & sql scripts
 COPY Makefile /contours/Makefile
 COPY sql /sql
-
 WORKDIR /contours
-
 ENTRYPOINT ["/bin/bash", "-c", "sleep 10s && export OGR_GEOJSON_MAX_OBJ_SIZE=100000MB && /usr/bin/make"]
 CMD ["all"]


### PR DESCRIPTION
Through the PPA repository newer library versions, which are not compatible with the ubuntu version of the base image, have been pulled. Build failed. 
Updated the ubuntu image and removed the PPA repo.